### PR TITLE
TEC-7771 Ensure StringUtil.isInvisibleChar doesn't consider zero width non-join characters

### DIFF
--- a/src/main/java/org/jsoup/internal/StringUtil.java
+++ b/src/main/java/org/jsoup/internal/StringUtil.java
@@ -132,8 +132,8 @@ public final class StringUtil {
     }
 
     public static boolean isInvisibleChar(int c) {
-        return Character.getType(c) == 16 && (c == 8203 || c == 8204 || c == 8205 || c == 173);
-        // zero width sp, zw non join, zw join, soft hyphen
+        return Character.getType(c) == 16 && (c == 8203 || c == 8205 || c == 173);
+        // zero width sp, zw join, soft hyphen
     }
 
     /**

--- a/src/test/java/org/jsoup/internal/StringUtilTest.java
+++ b/src/test/java/org/jsoup/internal/StringUtilTest.java
@@ -100,4 +100,13 @@ public class StringUtilTest {
         assertEquals("ftp://example.com/one/two.c", resolve("ftp://example.com/one/", "./two.c"));
         assertEquals("ftp://example.com/one/two.c", resolve("ftp://example.com/one/", "two.c"));
     }
+    
+    @Test public void isInvisibleChar() {
+        assertTrue(StringUtil.isInvisibleChar('\u200B'));
+        assertTrue(StringUtil.isInvisibleChar('\u200D'));
+        assertTrue(StringUtil.isInvisibleChar('\u00AD'));
+        
+        assertFalse(StringUtil.isInvisibleChar('\u200C'));
+        assertFalse(StringUtil.isInvisibleChar(' '));
+    }
 }

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -1214,7 +1214,7 @@ public class ElementTest {
     }
 
     @Test public void testNormalizesInvisiblesInText() {
-        // return Character.getType(c) == 16 && (c == 8203 || c == 8204 || c == 8205 || c == 173);
+        // return Character.getType(c) == 16 && (c == 8203 || c == 8205 || c == 173);
         String escaped = "This&shy;is&#x200b;one&#x200d;word";
         String decoded = "This\u00ADis\u200Bone\u200Dword"; // browser would not display those soft hyphens / other chars, so we don't want them in the text
 

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -1215,19 +1215,19 @@ public class ElementTest {
 
     @Test public void testNormalizesInvisiblesInText() {
         // return Character.getType(c) == 16 && (c == 8203 || c == 8204 || c == 8205 || c == 173);
-        String escaped = "This&shy;is&#x200b;one&#x200c;long&#x200d;word";
-        String decoded = "This\u00ADis\u200Bone\u200Clong\u200Dword"; // browser would not display those soft hyphens / other chars, so we don't want them in the text
+        String escaped = "This&shy;is&#x200b;one&#x200d;word";
+        String decoded = "This\u00ADis\u200Bone\u200Dword"; // browser would not display those soft hyphens / other chars, so we don't want them in the text
 
         Document doc = Jsoup.parse("<p>" + escaped);
         Element p = doc.select("p").first();
         doc.outputSettings().charset("ascii"); // so that the outer html is easier to see with escaped invisibles
-        assertEquals("Thisisonelongword", p.text()); // text is normalized
+        assertEquals("Thisisoneword", p.text()); // text is normalized
         assertEquals("<p>" + escaped + "</p>", p.outerHtml()); // html / whole text keeps &shy etc;
         assertEquals(decoded, p.textNodes().get(0).getWholeText());
 
-        Element matched = doc.select("p:contains(Thisisonelongword)").first(); // really just oneloneword, no invisibles
+        Element matched = doc.select("p:contains(Thisisoneword)").first(); // really just oneloneword, no invisibles
         assertEquals("p", matched.nodeName());
-        assertTrue(matched.is(":containsOwn(Thisisonelongword)"));
+        assertTrue(matched.is(":containsOwn(Thisisoneword)"));
 
     }
 	


### PR DESCRIPTION
## [TEC-7771](https://jira.echobox.com/browse/TEC-7771)

### Spec 
Not Applicable

### Priority
MAJOR

### Description of Changes
- Ensure ZWNJ characters aren't stripped as they're not invisible characters

### Documentation
Not Applicable

### Risks & Impacts
- Will consider ZWNJ as non-invisible characters as will consider the character in the string builder

### Security
-  N/A

### Testing
- Added and updated unit tests